### PR TITLE
fix: comic CI push without post-commit rebase

### DIFF
--- a/.github/workflows/profile-comic.yml
+++ b/.github/workflows/profile-comic.yml
@@ -55,6 +55,13 @@ jobs:
     steps:
       - name: Checkout default branch
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Sync with remote after waka job
+        run: |
+          git fetch origin "${{ github.event.repository.default_branch }}"
+          git reset --hard "origin/${{ github.event.repository.default_branch }}"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -90,16 +97,33 @@ jobs:
 
       - name: Commit and push if changed
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # -A stages adds and deletes (e.g. clearing .last_wakatime_hash on placeholder runs).
-          git add -A -- README.md COMIC_BOOK.md assets/comic/ .github/.last_wakatime_hash
+          BRANCH="${{ github.event.repository.default_branch }}"
+          # -A stages adds and deletes (e.g. demo run clears .last_wakatime_hash).
+          COMIC_PATHS="README.md COMIC_BOOK.md assets/comic/ .github/.last_wakatime_hash"
+
+          git add -A -- ${COMIC_PATHS}
           if git diff --staged --quiet; then
             echo "No README or comic asset changes to commit."
-          else
-            git commit -m "chore: refresh weekly dev comic"
-            # Sync with remote (commits that landed during the long generate step).
-            git fetch origin
-            git pull --rebase --autostash origin "${{ github.ref_name }}"
-            git push
+            exit 0
           fi
+
+          # Commit once on latest origin: stash comic output, sync, re-apply (no post-commit rebase).
+          git stash push -u -m "weekly-comic" -- ${COMIC_PATHS}
+          git fetch origin "${BRANCH}"
+          git reset --hard "origin/${BRANCH}"
+          if ! git stash pop; then
+            echo "::error::Comic changes conflicted with origin/${BRANCH}." >&2
+            git status
+            exit 1
+          fi
+
+          git add -A -- ${COMIC_PATHS}
+          if git diff --staged --quiet; then
+            echo "No changes after sync with origin/${BRANCH}."
+            exit 0
+          fi
+          git commit -m "chore: refresh weekly dev comic"
+          git push origin "HEAD:${BRANCH}"


### PR DESCRIPTION
## Summary

The failed run was still on commit `9466af1` (workflow from **before** PR #2 merged). Logs show the real trigger:

- `WakaTime stats empty or zero; using random demo stats.`
- `Cleared WakaTime hash file (demo run).`
- Old step used `if [ -f .github/.last_wakatime_hash ]; then git add …` **after** the file was deleted, so the deletion stayed unstaged and `git pull --rebase` failed.

PR #2’s `git add -A` would stage that deletion, but this PR makes the push path more reliable:

- After checkout, **reset to `origin/<default branch>`** so the comic job sees the waka job’s README push.
- **Stash → sync → stash pop → single commit → push** (no rebase after commit).

## Test plan

- [ ] Merge and run **Weekly profile** via workflow_dispatch.
- [ ] Confirm **Commit and push if changed** succeeds.
- [ ] (Optional) Fix `WAKATIME_API_KEY` / WakaTime data so scheduled runs don’t fall back to demo stats every week.


Made with [Cursor](https://cursor.com)